### PR TITLE
Syntax test fix

### DIFF
--- a/HTML-C#.sublime-syntax
+++ b/HTML-C#.sublime-syntax
@@ -44,18 +44,11 @@ contexts:
   block_cs:
     - match: '<%[=#:$]?'
       scope: punctuation.section.embedded.begin.cshtml
-      push:
-        - clear_scopes: true
-        - meta_content_scope: source.cs.embedded.html
-        - match: '%>'
-          scope: punctuation.section.embedded.end.cshtml
-          pop: true
-        - match: ''
-          push:
-            - include: 'scope:source.cs'
-          with_prototype:
-             - match: '(?=%>)'
-               pop: true
+      embed: scope:source.cs
+      embed_scope: source.cs.embedded.html
+      escape: '%>'
+      escape_captures:
+        0: punctuation.section.embedded.end.cshtml
 
   script_tag_cs:
     - match: (<)((?i:script))[^>]+(runat)(=)(?:((')server('))|((")server(")))
@@ -80,11 +73,8 @@ contexts:
           pop: true
         - match: '>'
           scope: punctuation.definition.tag.end.html
-          push:
-            - include: scope:source.cs
-          with_prototype:
-             - match: (?i)(?=</script)
-               pop: true
+          embed: scope:source.cs
+          escape: (?i)(?=</script)
         - include: scope:text.html.basic#tag-stuff
 
   comments:

--- a/syntax_test_aspx.aspx
+++ b/syntax_test_aspx.aspx
@@ -1,4 +1,4 @@
-// SYNTAX TEST "Packages/HTML-C#/HTML-C#.sublime-syntax"
+// SYNTAX TEST "Packages/HTML (C#)/HTML-C#.sublime-syntax"
 
 <%@ Page Debug="true" Title="" AutoEventWireup="true" Inherits="System.Web.UI.Page" %>
 // <-                 punctuation.section.embedded.begin.cshtml


### PR DESCRIPTION
This fixes the syntax tests referencing the wrong package name, and merges the `embed-syntax` branch now that a stable build with `embed` support has been available for a while.