### PR TITLE
Initial work on a Razor syntax

### DIFF
--- a/razor.sublime-syntax
+++ b/razor.sublime-syntax
@@ -11,7 +11,7 @@ contexts:
 
   html:
     - match: ''
-      set: razor_html
+      set: razor-html
 
   razor-comments:
     - match: '@\*'
@@ -43,7 +43,7 @@ contexts:
             - match: \}
               scope: punctuation.section.block.end.cshtml
               pop: true
-            - include: razor_html
+            - include: razor-html
     - match: (@)(functions)\b
       captures:
         1: punctuation.section.embedded.line.cshtml
@@ -78,7 +78,7 @@ contexts:
         - match: ''
           pop: true
       with_prototype:
-        - include: razor_block_prototype
+        - include: razor-block-prototype
     - match: '[\w-+]+@\w+' # ignore email addresses
     - match: '@(?=(?:\w+\.)*\w+(?:[<\s]|$))'
       scope: punctuation.section.embedded.line.cshtml
@@ -103,12 +103,12 @@ contexts:
     #- match: '@(?=\w+(?:\.\w+)*)(?!\s*[+=|(])' # TODO: support a.b[2] etc.
     #  comment: property/variable access
     #  scope: punctuation.section.embedded.line.cshtml
-    #  #push: razor_block # TODO: stop at closing " etc.
+    #  #push: razor-block # TODO: stop at closing " etc.
     - match: '@'
       scope: punctuation.section.embedded.line.cshtml
-      push: razor_block
+      push: razor-block
 
-  razor_block_prototype:
+  razor-block-prototype:
     - match: (?=[<&])
       embed: scope:text.html.basic
       escape: (?=[@}]|$)
@@ -117,11 +117,11 @@ contexts:
       embed: scope:text.html.basic
       escape: $
 
-  eat_whitespace:
+  eat-whitespace:
     - match: (?=\S)
       pop: true
 
-  razor_block:
+  razor-block:
     - meta_content_scope: source.cs.embedded.html
     - match: (?=[<\s])
       pop: true
@@ -129,8 +129,8 @@ contexts:
       push:
         - include: scope:source.cs#line_of_code
       with_prototype:
-        - include: razor_block_prototype
+        - include: razor-block-prototype
 
-  razor_html:
+  razor-html:
     - include: razor
     - include: scope:text.html.basic

--- a/razor.sublime-syntax
+++ b/razor.sublime-syntax
@@ -52,6 +52,7 @@ contexts:
         - match: \{
           scope: punctuation.section.block.begin.cshtml
           set:
+            - clear_scopes: 1
             - meta_scope: source.cs.embedded.functions.cshtml
             - match: \}
               scope: punctuation.section.block.end.cshtml
@@ -73,6 +74,7 @@ contexts:
       captures:
         1: punctuation.section.embedded.cshtml
       push:
+        - clear_scopes: 1
         - meta_content_scope: source.cs.embedded.html
         - include: scope:source.cs#line_of_code
         - match: ''
@@ -95,6 +97,7 @@ contexts:
     - match: '@\('
       scope: punctuation.section.embedded.begin.cshtml
       push:
+        - clear_scopes: 1
         - meta_content_scope: source.cs.embedded.html
         - match: \)
           scope: punctuation.section.embedded.end.cshtml
@@ -122,6 +125,7 @@ contexts:
       pop: true
 
   razor-block:
+    - clear_scopes: 1
     - meta_content_scope: source.cs.embedded.html
     - match: (?=[<\s])
       pop: true
@@ -132,5 +136,6 @@ contexts:
         - include: razor-block-prototype
 
   razor-html:
+    - meta_content_scope: text.html.basic
     - include: razor
     - include: scope:text.html.basic

--- a/razor.sublime-syntax
+++ b/razor.sublime-syntax
@@ -1,0 +1,136 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: HTML Razor (C#)
+file_extensions:
+  - cshtml
+scope: embedding.cshtml.razor
+contexts:
+  main:
+    - include: html
+
+  html:
+    - match: ''
+      set: razor_html
+
+  razor-comments:
+    - match: '@\*'
+      scope: punctuation.definition.comment.begin.cshtml
+      push:
+        - meta_scope: comment.block.cshtml
+        - match: '\*@'
+          scope: punctuation.definition.comment.end.cshtml
+          pop: true
+
+  razor:
+    - include: razor-comments
+    - match: (@)(model)\b
+      captures:
+        1: punctuation.section.embedded.line.cshtml
+        2: source.cs.embedded.html keyword.other.cshtml
+      embed: scope:source.cs
+      embed_scope: source.cs.embedded.html
+      escape: $
+    - match: (@)(section)\b(?:\s+(\w+))?
+      captures:
+        1: punctuation.section.embedded.line.cshtml
+        2: source.cs.embedded.html keyword.other.cshtml
+        3: entity.name.section.cshtml
+      push:
+        - match: \{
+          scope: punctuation.section.block.begin.cshtml
+          set:
+            - match: \}
+              scope: punctuation.section.block.end.cshtml
+              pop: true
+            - include: razor_html
+    - match: (@)(functions)\b
+      captures:
+        1: punctuation.section.embedded.line.cshtml
+        2: source.cs.embedded.html keyword.other.cshtml
+      push:
+        - match: \{
+          scope: punctuation.section.block.begin.cshtml
+          set:
+            - meta_scope: source.cs.embedded.functions.cshtml
+            - match: \}
+              scope: punctuation.section.block.end.cshtml
+              pop: true
+            - include: scope:source.cs#code_block_in
+        - match: \s*(?!\{)(?=\S)
+          scope: invalid.illegal.expected-block.cshtml
+          pop: true
+    - match: (@)(using)\b(?!\s*\()
+      captures:
+        1: punctuation.section.embedded.line.cshtml
+        2: source.cs.embedded.html keyword.other.cshtml
+      embed: scope:source.cs
+      embed_scope: source.cs.embedded.html
+      escape: $
+    - match: '@@'
+      scope: constant.character.escape.cshtml
+    - match: (@)(?=(?:if|switch|for|foreach|using|try|lock)\b)
+      captures:
+        1: punctuation.section.embedded.cshtml
+      push:
+        - meta_content_scope: source.cs.embedded.html
+        - include: scope:source.cs#line_of_code
+        - match: ''
+          pop: true
+      with_prototype:
+        - include: razor_block_prototype
+    - match: '[\w-+]+@\w+' # ignore email addresses
+    - match: '@(?=(?:\w+\.)*\w+(?:[<\s]|$))'
+      scope: punctuation.section.embedded.line.cshtml
+      embed: scope:source.cs#line_of_code_in
+      embed_scope: source.cs.embedded.html
+      escape: $|(?=[<\s])
+    - match: '@(?=(?:\w+\.)*\w+\()'
+      scope: punctuation.section.embedded.line.cshtml
+      push:
+        - meta_content_scope: source.cs.embedded.html
+        - match: (?=[<\s])
+          pop: true
+        - include: scope:source.cs#line_of_code_in
+    - match: '@\('
+      scope: punctuation.section.embedded.begin.cshtml
+      push:
+        - meta_content_scope: source.cs.embedded.html
+        - match: \)
+          scope: punctuation.section.embedded.end.cshtml
+          pop: true
+        - include: scope:source.cs#line_of_code_in
+    #- match: '@(?=\w+(?:\.\w+)*)(?!\s*[+=|(])' # TODO: support a.b[2] etc.
+    #  comment: property/variable access
+    #  scope: punctuation.section.embedded.line.cshtml
+    #  #push: razor_block # TODO: stop at closing " etc.
+    - match: '@'
+      scope: punctuation.section.embedded.line.cshtml
+      push: razor_block
+
+  razor_block_prototype:
+    - match: (?=[<&])
+      embed: scope:text.html.basic
+      escape: (?=[@}]|$)
+    - match: '@:'
+      scope: punctuation.section.embedded.html.cshtml
+      embed: scope:text.html.basic
+      escape: $
+
+  eat_whitespace:
+    - match: (?=\S)
+      pop: true
+
+  razor_block:
+    - meta_content_scope: source.cs.embedded.html
+    - match: (?=[<\s])
+      pop: true
+    - match: (?=\S)(?!@)
+      push:
+        - include: scope:source.cs#line_of_code
+      with_prototype:
+        - include: razor_block_prototype
+
+  razor_html:
+    - include: razor
+    - include: scope:text.html.basic

--- a/tests/syntax_test_cshtml.cshtml
+++ b/tests/syntax_test_cshtml.cshtml
@@ -1,0 +1,210 @@
+<!-- SYNTAX TEST "Packages/HTML (C#)/razor.sublime-syntax" -->
+<!-- https://docs.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-2.1 -->
+@using Michael.Blyons.Example
+<!-- <- punctuation.section.embedded.line - source.cs.embedded -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded -->
+<!-- ^ keyword.other -->
+<!--                         ^ - source.cs.embedded -->
+@model IEnumerable<SomeNamespace.SomeType>
+<!-- <- punctuation.section.embedded.line - source.cs.embedded -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded -->
+<!-- ^ keyword.other -->
+<!--   ^^^^^^^^^^^ support.type -->
+<!--              ^ punctuation.definition.generic.begin -->
+<!--               ^^^^^^^^^^^^^ support.type -->
+<!--                            ^ punctuation.accessor.dot.namespace -->
+<!--                             ^^^^^^^^ support.type -->
+<!--                                     ^ punctuation.definition.generic.end -->
+<!--                                      ^ - source.cs.embedded -->
+
+     <p>@@Username</p>
+<!-- ^^^ meta.tag.block.any -->
+<!--    ^^ constant.character.escape -->
+<!--              ^^^^ meta.tag.block.any -->
+
+     <p>@Username</p>
+<!-- ^^^ meta.tag.block.any -->
+<!--    ^ punctuation.section.embedded.line -->
+<!--     ^^^^^^^^ source.cs.embedded variable.other -->
+<!--             ^^^^ meta.tag.block.any -->
+
+<a href="mailto:Support@contoso.com">Support@contoso.com</a>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a - source.cs -->
+<!--                                 ^^^^^^^^^^^^^^^^^^^^^^^ - source.cs -->
+<!--                                                    ^^^^ meta.tag.inline.a -->
+
+<p>@DateTime.Now</p>
+<!-- ^^^^^^^ source.cs.embedded variable.other -->
+<!--        ^ source.cs.embedded punctuation.accessor.dot -->
+<!--         ^^^ source.cs.embedded variable.other -->
+<!--            ^^^ meta.tag.block.any -->
+<p>@DateTime.IsLeapYear(2016)</p>
+<!-- ^^^^^^^ source.cs.embedded variable.other -->
+<!--        ^ source.cs.embedded punctuation.accessor.dot -->
+<!--         ^^^^^^^^^^ source.cs.embedded meta.function-call variable.function -->
+<!--                   ^ punctuation.section.group.begin -->
+<!--                    ^^^^ constant.numeric.integer.decimal -->
+<!--                        ^ punctuation.section.group.end -->
+<!--                         ^^^ meta.tag.block.any -->
+
+     <p>@(GenericMethod<int>())</p>
+<!--    ^^ punctuation.section.embedded.begin -->
+<!--      ^^^^^^^^^^^^^ source.cs.embedded meta.function-call variable.function -->
+<!--                   ^ punctuation.definition.generic.begin -->
+<!--                    ^^^ storage.type -->
+<!--                       ^ punctuation.definition.generic.end -->
+<!--                        ^ punctuation.section.group.begin -->
+<!--                         ^ punctuation.section.group.end -->
+<!--                          ^ punctuation.section.embedded.end -->
+<!--                           ^^^ meta.tag.block.any -->
+
+@("<span>Hello World</span>")
+<!-- <- punctuation.section.embedded.begin -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double -->
+<!--                        ^ punctuation.section.embedded.end -->
+@Html.Raw("<span>Hello World</span>")
+<!--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call -->
+<!--  ^^^ variable.function -->
+<!-- <- punctuation.section.embedded.line -->
+<!--      ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double -->
+<!--                                ^ punctuation.section.group.end -->
+
+     @if (value % 2 == 0)
+<!-- ^ punctuation.section.embedded -->
+<!--  ^^ keyword.control.conditional.if -->
+{
+<!-- <- meta.block punctuation.section.block.begin -->
+    <p>The value was even.</p>
+<!--^^^ meta.tag.block.any -->
+}
+else if (value >= 1337)
+<!-- <- keyword.control.conditional.elseif -->
+{
+    <p>The value is large.</p>
+}
+else
+<!-- <- keyword.control.conditional.else -->
+{
+    <p>The value is odd and small.</p>
+}
+
+@switch (value)
+{
+    case 1:
+<!--^^^^ keyword.control.switch.case -->
+        <p>The value is 1!</p>
+        break;
+    case 1337:
+        <p>Your number is 1337!</p>
+        break;
+    default:
+        <p>Your number wasn't 1 or 1337.</p>
+        break;
+<!--    ^^^^^ keyword.control.flow.break -->
+}
+@*
+@for (var i = 0; i < people.Length; i++)
+<!-- <- comment.block - punctuation -->
+{
+    var person = people[i];
+    <text>Name: @person.Name</text>
+}
+
+@for (var i = 0; i < people.Length; i++)
+{
+    var person = people[i];
+    @:Name: @person.Name
+}     *@
+<!--  ^^ comment.block punctuation.definition.comment.end -->
+
+@{
+    var quote = "The future depends on what you do today. - Mahatma Gandhi";
+}
+
+<p>@quote</p>
+
+@{
+    quote = "Hate cannot drive out hate, only love can do that. - Martin Luther King, Jr.";
+}
+
+<p>@quote</p>
+
+@using (Html.BeginForm())
+{
+    <div>
+        email:
+<!-- TODO: what should the above be scoped as? -->
+        <input type="email" id="Email" value="">
+        <button>Register</button>
+    </div>
+}
+
+@try
+{
+    throw new InvalidOperationException("You did something invalid.");
+}
+catch (Exception ex)
+{
+    <p>The exception message: @ex.Message</p>
+}
+finally
+{
+    <p>The finally statement.</p>
+}
+
+@lock (SomeLock)
+{
+    // Do critical section work
+}
+
+@*
+    @{
+        /* C# comment */
+        // Another C# comment
+    }
+    <!-- HTML comment -->
+*@
+
+@functions {
+// <!-- ^^ keyword.other -->
+    public string GetHello()
+// <!-- ^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded.functions -->
+// <!-- ^^ storage.modifier.access -->
+    {
+        return "Hello";
+    }
+}
+<!-- ^ - source.cs.embedded.functions -->
+
+<div>From method: @GetHello()</div>
+
+<form id="searchForm" action="@Url.Action("Search", "Controller")" method="post">
+<!-- TODO: scope @ constructs in HTML attribute values correctly -->
+    <div style="@(HtmlHelpers.DevModeEnabled(Request) ? "display: none;" : "")">
+    </div>
+</form>
+
+<article data-example="@example.ID">
+</article>
+
+@foreach (var item in Model)
+{
+    if (item.ShouldBeDisplayed)
+    {
+        <article data-id="@item.ID">
+        <!-- TODO: scope at constructs in HTML attribute values correctly even when inside a razor code block -->
+        </article>
+    }
+}
+
+@section Scripts {
+<!--     ^^^^^^^ entity.name.section -->
+    <script type="text/javascript" src="/scripts/main.js"></script>
+<!-- ^^^^^^ entity.name.tag.script -->
+
+    <script type="text/javascript">
+        function find() {
+            var val = $('@HtmlHelpers.Something').val();
+        }
+    </script>
+}

--- a/tests/syntax_test_cshtml.cshtml
+++ b/tests/syntax_test_cshtml.cshtml
@@ -1,10 +1,10 @@
 <!-- SYNTAX TEST "Packages/HTML (C#)/razor.sublime-syntax" -->
 <!-- https://docs.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-2.1 -->
-@using Michael.Blyons.Example
+@using System.Collections.Generic
 <!-- <- punctuation.section.embedded.line - source.cs.embedded -->
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded -->
 <!-- ^ keyword.other -->
-<!--                         ^ - source.cs.embedded -->
+<!--                             ^ - source.cs.embedded -->
 @model IEnumerable<SomeNamespace.SomeType>
 <!-- <- punctuation.section.embedded.line - source.cs.embedded -->
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded -->

--- a/tests/syntax_test_cshtml.cshtml
+++ b/tests/syntax_test_cshtml.cshtml
@@ -18,8 +18,9 @@
 <!--                                      ^ - source.cs.embedded -->
 
      <p>@@Username</p>
-<!-- ^^^ meta.tag.block.any -->
+<!-- ^^^ text.html meta.tag.block.any -->
 <!--    ^^ constant.character.escape -->
+<!--      ^^^^^^^^^^^^^ text.html -->
 <!--              ^^^^ meta.tag.block.any -->
 
      <p>@Username</p>
@@ -31,6 +32,7 @@
 <a href="mailto:Support@contoso.com">Support@contoso.com</a>
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a - source.cs -->
 <!--                                 ^^^^^^^^^^^^^^^^^^^^^^^ - source.cs -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html -->
 <!--                                                    ^^^^ meta.tag.inline.a -->
 
 <p>@DateTime.Now</p>
@@ -49,7 +51,8 @@
 
      <p>@(GenericMethod<int>())</p>
 <!--    ^^ punctuation.section.embedded.begin -->
-<!--      ^^^^^^^^^^^^^ source.cs.embedded meta.function-call variable.function -->
+<!--      ^^^^^^^^^^^^^^^^^^^^ source.cs.embedded - text.html -->
+<!--      ^^^^^^^^^^^^^ meta.function-call variable.function -->
 <!--                   ^ punctuation.definition.generic.begin -->
 <!--                    ^^^ storage.type -->
 <!--                       ^ punctuation.definition.generic.end -->
@@ -60,7 +63,7 @@
 
 @("<span>Hello World</span>")
 <!-- <- punctuation.section.embedded.begin -->
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^ source.cs string.quoted.double - text.html -->
 <!--                        ^ punctuation.section.embedded.end -->
 @Html.Raw("<span>Hello World</span>")
 <!--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call -->
@@ -70,8 +73,8 @@
 <!--                                ^ punctuation.section.group.end -->
 
      @if (value % 2 == 0)
-<!-- ^ punctuation.section.embedded -->
-<!--  ^^ keyword.control.conditional.if -->
+<!-- ^ punctuation.section.embedded - source.cs -->
+<!--  ^^ source.cs keyword.control.conditional.if - text.html -->
 {
 <!-- <- meta.block punctuation.section.block.begin -->
     <p>The value was even.</p>
@@ -119,7 +122,9 @@ else
 
 @{
     var quote = "The future depends on what you do today. - Mahatma Gandhi";
+<!-- ^^ source.cs.embedded - text.html -->
 }
+<!-- ^ text.html - source -->
 
 <p>@quote</p>
 


### PR DESCRIPTION
Hi,

I did a little work on support for Razor syntax `.cshtml` files, and thought I'd share it here. It's not perfect, probably one would need to use [YAMLMacros](https://packagecontrol.io/packages/YAMLMacros) to extend the `HTML` syntax to get it to handle C# code in HTML attributes properly etc., but I believe it is better than not having Razor syntax highlighted at all.