### PR TITLE
Prepare for C# `version: 2`

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -28,7 +28,7 @@ jobs:
             packages: master
           - build: stable
             packages: master
-          - build: 4201
+          - build: 4204
             packages: binary
     steps:
       - uses: actions/checkout@v6

--- a/Razor/C# (Razor).sublime-syntax
+++ b/Razor/C# (Razor).sublime-syntax
@@ -34,7 +34,3 @@ contexts:
   inside_verbatim_format_string_syntax:
     - meta_include_prototype: false
     - include: immediately_pop
-
-  immediately_pop:
-    - match: ''
-      pop: 1

--- a/Razor/C# (Razor).sublime-syntax
+++ b/Razor/C# (Razor).sublime-syntax
@@ -2,7 +2,7 @@
 ---
 scope: source.cs.embedded.html.cs.razor
 hidden: true
-# version: 2
+version: 2
 
 extends: Packages/C#/C#.sublime-syntax
 

--- a/Razor/embeddings/C# (for C# Razor HTML attribute).sublime-syntax
+++ b/Razor/embeddings/C# (for C# Razor HTML attribute).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 scope: source.cs.embedded.html-attribute-string.razor
-version: 1
+version: 2
 hidden: true
 
 extends: Packages/HTML (C#)/Razor/C# (Razor).sublime-syntax

--- a/Razor/tests/syntax_test_cshtml.cshtml
+++ b/Razor/tests/syntax_test_cshtml.cshtml
@@ -7,14 +7,15 @@
 <!--                             ^ - source.cs.embedded -->
 @model IEnumerable<SomeNamespace.SomeType>
 <!-- <- punctuation.section.embedded.line - source.cs.embedded -->
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded -->
-<!-- ^ keyword.other -->
-<!--   ^^^^^^^^^^^ support.type -->
-<!--              ^ punctuation.definition.generic.begin -->
-<!--               ^^^^^^^^^^^^^ support.type -->
-<!--                            ^ punctuation.accessor.dot.namespace -->
-<!--                             ^^^^^^^^ support.type -->
-<!--                                     ^ punctuation.definition.generic.end -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded.html -->
+<!--^^ keyword.other.cs-razor -->
+<!--   ^^^^^^^^^^^ support.type.cs -->
+<!--              ^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.cs -->
+<!--              ^ punctuation.definition.generic.begin.cs -->
+<!--               ^^^^^^^^^^^^^ support.type.cs -->
+<!--                            ^ punctuation.accessor.dot.cs -->
+<!--                             ^^^^^^^^ support.type.cs -->
+<!--                                     ^ punctuation.definition.generic.end.cs -->
 <!--                                      ^ - source.cs.embedded -->
 
      <p>@@Username</p>
@@ -41,18 +42,28 @@
 <!--    ^^ punctuation.definition.comment.block.end.cs-razor -->
 
 <p>@DateTime.Now</p>
-<!-- ^^^^^^^ source.cs.embedded variable.other -->
-<!--        ^ source.cs.embedded punctuation.accessor.dot -->
-<!--         ^^^ source.cs.embedded variable.other -->
-<!--            ^^^ meta.tag.block.any -->
+<!--^^^^^^^^^^^^ source.cs.embedded.html -->
+<!--^^^^^^^^ variable.other.cs -->
+<!--        ^ punctuation.accessor.dot.cs -->
+<!--         ^^^ variable.other.cs -->
+<!--            ^^^^ meta.tag.block.any.html -->
+<!--            ^^ punctuation.definition.tag.begin.html -->
+<!--              ^ entity.name.tag.block.any.html -->
+<!--               ^ punctuation.definition.tag.end.html -->
 <p>@DateTime.IsLeapYear(2016)</p>
-<!-- ^^^^^^^ source.cs.embedded variable.other -->
-<!--        ^ source.cs.embedded punctuation.accessor.dot -->
-<!--         ^^^^^^^^^^ source.cs.embedded meta.function-call variable.function -->
-<!--                   ^ punctuation.section.group.begin -->
-<!--                    ^^^^ constant.numeric -->
-<!--                        ^ punctuation.section.group.end -->
-<!--                         ^^^ meta.tag.block.any -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^ source.cs.embedded.html -->
+<!--^^^^^^^^ variable.other.cs -->
+<!--        ^ punctuation.accessor.dot.cs -->
+<!--         ^^^^^^^^^^^^^^^^ meta.function-call.cs -->
+<!--         ^^^^^^^^^^ variable.function.cs -->
+<!--                   ^^^^^^ meta.group.cs -->
+<!--                   ^ punctuation.section.group.begin.cs -->
+<!--                    ^^^^ meta.number.integer.decimal.cs constant.numeric.value.cs -->
+<!--                        ^ punctuation.section.group.end.cs -->
+<!--                         ^^^^ meta.tag.block.any.html -->
+<!--                         ^^ punctuation.definition.tag.begin.html -->
+<!--                           ^ entity.name.tag.block.any.html -->
+<!--                            ^ punctuation.definition.tag.end.html -->
 
      <p>@(GenericMethod<int>())</p>
 <!--    ^^ punctuation.section.embedded.begin -->
@@ -99,7 +110,10 @@ else
 @switch (value)
 {
     case 1:
-<!--^^^^ keyword.control.switch.case -->
+<!--^^^^^^^^ meta.block.cs -->
+<!--^^^^ keyword.control.conditional.case.cs -->
+<!--     ^ meta.number.integer.decimal.cs constant.numeric.value.cs -->
+<!--      ^ punctuation.separator.case-statement.cs -->
         <p>The value is 1!</p>
         break;
     case 1337:
@@ -134,9 +148,10 @@ else
 
 @{
     var quote = "The future depends on what you do today. - Mahatma Gandhi";
-<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.cs source.cs.embedded.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.cs source.cs.embedded.html -->
+<!--^^^ storage.type.variable.cs -->
 <!--    ^^^^^ variable.other.cs -->
-<!--          ^ keyword.operator.assignment.variable.cs -->
+<!--          ^ keyword.operator.assignment.cs -->
 <!--            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.quoted.double.cs -->
 <!--            ^ punctuation.definition.string.begin.cs -->
 <!--                                                                      ^ punctuation.definition.string.end.cs -->
@@ -262,7 +277,7 @@ else
 <!--                               ^^^^^ variable.language.this.razor -->
 <!--                                    ^ punctuation.accessor.dot.cs -->
 <!--                                     ^^^^^^^^^^^ variable.other.cs -->
-<!--                                                 ^ keyword.operator.cs -->
+<!--                                                 ^ keyword.operator.arithmetic.cs -->
 <!--                                                   ^ meta.number.integer.decimal.cs constant.numeric.value.cs -->
 <!--                                                    ^ punctuation.section.group.end.cs -->
 <!--                                                     ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html -->
@@ -271,6 +286,7 @@ else
 <!--                                                        ^^ punctuation.definition.tag.begin.html -->
 <!--                                                          ^ entity.name.tag.inline.any.html -->
 <!--                                                           ^ punctuation.definition.tag.end.html -->
+
 </li>
 <li>
     <a href="@Model.FunctionCall("embedded string")">"quotes" everywhere</a>

--- a/WebForms/C# (WebForms).sublime-syntax
+++ b/WebForms/C# (WebForms).sublime-syntax
@@ -2,7 +2,7 @@
 ---
 scope: source.cs.embedded.html.cs.webforms
 hidden: true
-# version: 2
+version: 2
 
 extends: Packages/C#/C#.sublime-syntax
 

--- a/WebForms/ashx.sublime-syntax
+++ b/WebForms/ashx.sublime-syntax
@@ -3,6 +3,7 @@
 # http://www.sublimetext.com/docs/syntax.html
 name: .Net Web Handler (ASHX)
 scope: source.cs.webforms.ashx
+version: 2
 
 extends: Packages/C#/C#.sublime-syntax
 

--- a/WebForms/tests/syntax_test_ashx.ashx
+++ b/WebForms/tests/syntax_test_ashx.ashx
@@ -21,7 +21,7 @@ using System;
 using System.Web;
 //^^^ keyword.control.import.cs
 //    ^^^^^^^^^^ meta.path.cs
-//          ^ punctuation.separator.namespace.cs
+//          ^ punctuation.accessor.dot.cs
 //              ^ punctuation.terminator.statement.cs
 
 public class Handler : IHttpHandler


### PR DESCRIPTION
In https://github.com/sublimehq/Packages/pull/4504, the base C# is migrating to Sublime Syntax version 2. All of our children that `extends` it need to follow suit.

This will require a new tag series when it ships with Sublime Text.

A couple of lessons learned may be useful to backport to the existing syntax.